### PR TITLE
Fix compilation error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,9 +2,9 @@ import PackageDescription
 
 let package = Package(
   name: "BluemixAppID",
-	dependencies:[
-		.Package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", majorVersion: 1, minor: 6),
+  dependencies:[
+    .Package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", majorVersion: 1, minor: 6),
     .Package(url: "https://github.com/IBM-Swift/Kitura-Request.git", majorVersion: 0, minor: 7),
-		.Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", majorVersion: 0, minor: 5)
-	]
+    .Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", majorVersion: 0, minor: 5)
+  ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
 import PackageDescription
 
 let package = Package(
-    name: "BluemixAppID",
+  name: "BluemixAppID",
 	dependencies:[
 		.Package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", majorVersion: 1, minor: 6),
-        .Package(url: "https://github.com/IBM-Swift/Kitura-Request.git", majorVersion: 0),
+    .Package(url: "https://github.com/IBM-Swift/Kitura-Request.git", majorVersion: 0, minor: 7),
 		.Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", majorVersion: 0, minor: 5)
 	]
 )


### PR DESCRIPTION
The current version of this Swift package fails to compile due to dependency issues:

```
$ swift build
Cloning https://github.com/IBM-Swift/Kitura-Credentials.git
HEAD is now at a2d5c84 Updated dependencies
Resolved version: 1.6.0
Cloning https://github.com/IBM-Swift/Kitura.git
HEAD is now at 6b0cd19 Fix test printing warnings 
Resolved version: 1.6.3
Cloning https://github.com/IBM-Swift/Kitura-net.git
HEAD is now at 34176a2 Merge the memory leak fixes into master (#176)
Resolved version: 1.6.2
Cloning https://github.com/IBM-Swift/LoggerAPI.git
HEAD is now at 1e6f08e Perf: Use autoclosures to prevent String construction (#18)
Resolved version: 1.6.0
Cloning https://github.com/IBM-Swift/BlueSocket.git
HEAD is now at 1e15729 Updated the version in the pod spec to the soon to be next version.
Resolved version: 0.12.45
Cloning https://github.com/IBM-Swift/CCurl.git
HEAD is now at 3cfb752 Add header callback helper function (#9)
Resolved version: 0.2.3
Cloning https://github.com/IBM-Swift/BlueSSLService.git
HEAD is now at 7ee123a Updated the requirements and recommendations.  Now recommending Swift 3.1 and Xcode 8.3.1.  No code changes.  This is strictly a documentation update.
Resolved version: 0.12.32
Cloning https://github.com/IBM-Swift/SwiftyJSON.git
HEAD is now at 7d78e6a Conditional Swift 3.1 support
Resolved version: 15.0.6
Cloning https://github.com/IBM-Swift/Kitura-TemplateEngine.git
HEAD is now at d876e99 An alternative implementation of PR https://github.com/IBM-Swift/Kitura-TemplateEngine/pull/11 (#12)
Resolved version: 1.6.0
Cloning https://github.com/IBM-Swift/Kitura-Session.git
HEAD is now at 9e67d5a working on managing error changes in 3.1
Resolved version: 1.6.1
Cloning https://github.com/IBM-Swift/BlueCryptor.git
HEAD is now at b269ee8 Updated the requirements and recommendations.  Now recommending Swift 3.1 and Xcode 8.3.1.  No code changes.  This is strictly a documentation update.
Resolved version: 0.8.10
Cloning https://github.com/IBM-Swift/CommonCrypto.git
HEAD is now at 02a5c05 Merge pull request #4 from Bouke/master
Resolved version: 0.1.4
Cloning https://github.com/IBM-Swift/Kitura-Request.git
HEAD is now at 2a045a0 IBM-Swift/Kitura#1047 Swift 3.1 changes
Resolved version: 0.8.0
error: The dependency graph could not be satisfied (https://github.com/IBM-Swift/Kitura-net.git)
```

This is causing issues in our tools such as the Bluemix CLI. This PR addresses this issue and makes this Swift package compile and execute with Swift 3.0.2 (this is the Swift version still version used in the Bluemix CLI).