### PR TITLE
Update Kitura-Request to 0.9.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
         )
     ],
     dependencies: [
-      .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", .upToNextMinor(from: "2.0.0")),
-      .package(url: "https://github.com/IBM-Swift/Kitura-Request.git", .upToNextMinor(from: "0.8.0")),
+      .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.0.0"),
+      .package(url: "https://github.com/IBM-Swift-Sunset/Kitura-Request.git", .upToNextMinor(from: "0.9.0")),
       .package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", .upToNextMinor(from: "0.5.0")),
     ],
     targets: [


### PR DESCRIPTION
Also broaden version of Kitura-Credentials to 2.x (from 2.0.x)

This is required to support Kitura 2.1.x.