### PR TITLE
add swiftyJSON to package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,8 @@ let package = Package(
         )
     ],
     dependencies: [
+      .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", from: "17.0.0"),
+      .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "2.0.0"),
       .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.0.0"),
       .package(url: "https://github.com/IBM-Swift-Sunset/Kitura-Request.git", .upToNextMinor(from: "0.9.0")),
       .package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", .upToNextMinor(from: "0.5.0")),
@@ -33,7 +35,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "BluemixAppID",
-            dependencies: ["Credentials", "KituraRequest", "SimpleLogger"]
+            dependencies: ["Credentials", "KituraRequest", "SimpleLogger", "SwiftyJSON", "KituraSession"]
         ),
         .testTarget(
             name: "BluemixAppIDTests",


### PR DESCRIPTION
SwiftyJSON was removed as a dependency in Kitura-Sessions. Since swiftyJSON and Kitura-Session were brought in by Kitura-Credentials the braking change was taken causing the current version of this repo not to compile. 

This pull request defines the version of swiftyJSON and Kitura-Session used within the application so that it compiles and all tests pass.

This is a fix for issue #35 