### PR TITLE
Enable tests on Linux

### DIFF
--- a/Tests/BluemixAppIDTests/UserAttributesManagerTest.swift
+++ b/Tests/BluemixAppIDTests/UserAttributesManagerTest.swift
@@ -26,6 +26,17 @@ import Socket
 @testable import BluemixAppID
 
 class UserAttributesManagerTest: XCTestCase {
+    
+    static var allTests : [(String, (UserAttributesManagerTest) -> () throws -> Void)] {
+        return [
+            ("testInit", testInit),
+            ("testSetAttribute", testSetAttribute),
+            ("testGetAttribute", testGetAttribute),
+            ("testDeleteAttribute", testDeleteAttribute),
+            ("testGetAllAttributes", testGetAllAttributes),
+        ]
+    }
+
     class MockUserAttributeManger : UserAttributeManager {
 
         override func handleRequest(attributeName: String?, attributeValue: String?, method:String, accessToken: String,completionHandler: @escaping (Swift.Error?, [String:Any]?) -> Void) {

--- a/Tests/BluemixAppIDTests/UtilsTest.swift
+++ b/Tests/BluemixAppIDTests/UtilsTest.swift
@@ -31,6 +31,13 @@ import SwiftyJSON
 
 class UtilsTest: XCTestCase {
 
+    static var allTests : [(String, (UtilsTest) -> () throws -> Void)] {
+        return [
+            ("testIsTokenValid", testIsTokenValid),
+            ("testUserIdentity", testUserIdentity),
+            ("testAuthorizationContext", testAuthorizationContext),
+        ]
+    }
 
     func testIsTokenValid() {
         XCTAssertFalse(Utils.isTokenValid(token: TestConstants.MALFORMED_ACCESS_TOKEN))

--- a/Tests/BluemixAppIDTests/WebAppPluginTest.swift
+++ b/Tests/BluemixAppIDTests/WebAppPluginTest.swift
@@ -30,6 +30,15 @@ import Foundation
 @testable import BluemixAppID
 
 class WebAppPluginTest: XCTestCase {
+
+    static var allTests : [(String, (WebAppPluginTest) -> () throws -> Void)] {
+        return [
+            ("testWebConfig", testWebConfig),
+            ("testLogout", testLogout),
+            ("testWebAuthenticate", testWebAuthenticate),
+            ("testHandleTokenResponse", testHandleTokenResponse),
+        ]
+    }
     
     let options = [
         "clientId": "86148468-1d73-48ac-9b5c-aaa86a34597a",

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,4 +3,7 @@ import XCTest
 
 XCTMain([
      testCase(BluemixAppIDTests.allTests),
+     testCase(UserAttributesManagerTest.allTests),
+     testCase(UtilsTest.allTests),
+     testCase(WebAppPluginTest.allTests),
 ])


### PR DESCRIPTION
While helping @kyemaloy97 to debug a testcase failure, we discovered that the tests do not appear to be working on Linux.

I have mechanically added them, and they mostly fail for me - I don't know whether this is expected or not.