### PR TITLE
Refactor Config / Constants

### DIFF
--- a/Sources/BluemixAppID/APIKituraCredentialsPlugin.swift
+++ b/Sources/BluemixAppID/APIKituraCredentialsPlugin.swift
@@ -64,13 +64,13 @@ public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
             requiredScope += " " + opts
         }
 
-        guard let authHeaderComponents = request.headers[APIKituraCredentialsPlugin.AuthHeader]?.components(separatedBy: " ") else {
+        guard let authHeaderComponents = request.headers[Constants.authHeader]?.components(separatedBy: " ") else {
             logger.warn("Authorization header not found")
             sendUnauthorized(scope: requiredScope, error: .missingAuth, completion: onPass, response: response)
             return
         }
 
-        guard authHeaderComponents.first == APIKituraCredentialsPlugin.Bearer else {
+        guard authHeaderComponents.first == Constants.bearer else {
             logger.warn("Unrecognized Authorization Method")
             sendUnauthorized(scope: requiredScope, error: .invalidRequest, completion: onPass, response: response)
             return
@@ -303,7 +303,7 @@ public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
                                   response: RouterResponse) {
         logger.debug("sendUnauthorized")
 
-        var msg = APIKituraCredentialsPlugin.Bearer + " scope=\"" + scope + "\", error=\"" + error.rawValue + "\""
+        var msg = Constants.bearer + " scope=\"" + scope + "\", error=\"" + error.rawValue + "\""
         var status: HTTPStatusCode!
 
         switch error {
@@ -313,17 +313,9 @@ public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
         case .internalServerError: status = .unauthorized
         case .missingAuth        :
             status = .unauthorized
-            msg = APIKituraCredentialsPlugin.Bearer + " realm=\"AppID\""
+            msg = Constants.bearer + " realm=\"AppID\""
         }
 
         completion(status, ["Www-Authenticate": msg])
     }
-}
-
-// Constants
-@available(OSX 10.12, *)
-extension APIKituraCredentialsPlugin {
-
-    fileprivate static let Bearer = "Bearer"
-    fileprivate static let AuthHeader = "Authorization"
 }

--- a/Sources/BluemixAppID/APIKituraCredentialsPlugin.swift
+++ b/Sources/BluemixAppID/APIKituraCredentialsPlugin.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 IBM Corp.
+ Copyright 2018 IBM Corp.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import SwiftyJSON
 @available(OSX 10.12, *)
 public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
 
-    private let logger = Logger(forName: "APIKituraCredentialsPlugin")
+    private let logger = Logger(forName: Constants.APIPlugin.name)
 
     // kid : pemPkcs
     private var appIDpubKeys: [String: String]?
@@ -35,15 +35,16 @@ public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
     public var usersCache: NSCache<NSString, BaseCacheElement>?
 
     public var name: String {
-        return APIKituraCredentialsPlugin.name
+        return Constants.APIPlugin.name
     }
 
     public init(options: [String: Any]?) {
-        logger.debug("Intializing APIKituraCredentialsPlugin")
+        logger.debug("Intializing " + Constants.APIPlugin.name)
         logger.warn("This is a beta version of APIKituraCredentialsPlugin." +
                     "It should not be used for production environments!")
 
         serviceConfig = APIKituraCredentialsPluginConfig(options: options)
+
         retrievePubKey()
     }
 
@@ -57,7 +58,7 @@ public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
 
         logger.debug("authenticate")
 
-        var requiredScope = APIKituraCredentialsPlugin.DefaultScope
+        var requiredScope = Constants.AppID.defaultScope
 
         if let opts = options["scope"] as? String {
             requiredScope += " " + opts
@@ -149,7 +150,7 @@ public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
         /// Merge authorization context and identity context, if necessary
         identityContext.forEach { authorizationContext[$0] = $1 }
 
-        request.userInfo[APIKituraCredentialsPlugin.AuthContext] = authorizationContext
+        request.userInfo[Constants.AuthContext.name] = authorizationContext
         onSuccess(profile)
     }
 
@@ -323,10 +324,6 @@ public class APIKituraCredentialsPlugin: CredentialsPluginProtocol {
 @available(OSX 10.12, *)
 extension APIKituraCredentialsPlugin {
 
-    public static let name = "appid-api-kitura-credentials-plugin"
-
     fileprivate static let Bearer = "Bearer"
     fileprivate static let AuthHeader = "Authorization"
-    fileprivate static let DefaultScope = "appid_default"
-    fileprivate static let AuthContext = "APPID_AUTH_CONTEXT"
 }

--- a/Sources/BluemixAppID/APIKituraCredentialsPluginConfig.swift
+++ b/Sources/BluemixAppID/APIKituraCredentialsPluginConfig.swift
@@ -15,7 +15,7 @@ import Foundation
 import SwiftyJSON
 import SimpleLogger
 
-internal class APIKituraCredentialsPluginConfig: CredentialsPluginConfig {
+internal class APIKituraCredentialsPluginConfig: AppIDPluginConfig {
 
     private let logger = Logger(forName: Constants.APIPlugin.name)
 

--- a/Sources/BluemixAppID/APIKituraCredentialsPluginConfig.swift
+++ b/Sources/BluemixAppID/APIKituraCredentialsPluginConfig.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 IBM Corp.
+ Copyright 2018 IBM Corp.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -15,68 +15,35 @@ import Foundation
 import SwiftyJSON
 import SimpleLogger
 
-internal class APIKituraCredentialsPluginConfig {
+internal class APIKituraCredentialsPluginConfig: CredentialsPluginConfig {
 
-    private let vcapServices = "VCAP_SERVICES"
-    private let vcapServicesCredentials = "credentials"
-    private let vcapServicesName = "AppID"
-    private let vcapApplication = "VCAP_APPLICATION"
-    private let oauthServerURL = "oauthServerUrl"
-    private let pubkeyServerURL = "pubKeyServerUrl"
-    private let logger = Logger(forName: "APIKituraCredentialsPluginConfig")
+    private let logger = Logger(forName: Constants.APIPlugin.name)
 
-    internal var isTesting: Bool {
-        return serverUrl == "testServerUrl"
-    }
-
-    internal var config: [String: Any] {
-        return serviceConfig
-    }
-
-    internal var serverUrl: String? {
-        return serviceConfig[oauthServerURL] as? String
-    }
-
-    internal var publicKeyServerURL: String? {
-        var keyURL: String? = nil
-
-        // public key url = OAUTH_SERVER_URL/publickey
-        // e.g. https://appid-oauth.ng.bluemix.net/oauth/v3/a8589e38-081e-4128-a777-b1cd76ee1875/publickey
-        if let serverUrl = serviceConfig[oauthServerURL] as? String {
+    var publicKeyServerURL: String? {
+        if let serverUrl = serverUrl {
             if serverUrl.last == "/" {
-                keyURL = serverUrl + "./publickeys"
+                var endpoint = Constants.Endpoints.publicKeys
+                endpoint.removeFirst()
+                return serverUrl + endpoint
             } else {
-                keyURL = serverUrl + "/publickeys"
+                return serverUrl + Constants.Endpoints.publicKeys
             }
         }
-        return keyURL
+        return nil
     }
 
-    internal var serviceConfig: [String:Any] = [:]
+    override init(options: [String: Any]?) {
+        logger.debug("Intializing")
 
-    public init(options: [String: Any]?) {
-        logger.debug("Intializing APIKituraCredentialsPluginConfig")
+        super.init(options: options)
 
-        let options = options ?? [:]
-        let vcapString = ProcessInfo.processInfo.environment[self.vcapServices] ?? ""
-        let vcapServices = JSON.parse(string: vcapString)
-        var vcapServiceCredentials: [String: Any]? = [:]
-
-        if let dict = vcapServices.dictionary {
-            for (key, value) in dict {
-                if key.hasPrefix(vcapServicesName) {
-                    vcapServiceCredentials = (value.array?[0])?.dictionaryObject?[vcapServicesCredentials] as? [String : Any]
-                    break
-                }
-            }
+        if serviceConfig[Constants.Credentials.oauthServerUrl] == nil {
+            logger.error("Failed to initialize APIKituraCredentialsPlugin." +
+                         " All requests to protected endpoints will be rejected" +
+                         " Ensure your app is either bound to an AppID service instance" +
+                         " or pass required parameters in the strategy constructor ")
         }
 
-        serviceConfig[oauthServerURL] = options[oauthServerURL] ?? vcapServiceCredentials?[oauthServerURL] ?? nil
-
-        if serviceConfig[oauthServerURL] == nil {
-            logger.error("Failed to initialize APIKituraCredentialsPlugin. All requests to protected endpoints will be rejected")
-            logger.error("Ensure your app is either bound to an AppID service instance or pass required parameters in the strategy constructor ")
-        }
-        logger.info(oauthServerURL + "=" + ((serviceConfig[oauthServerURL] as? String) ?? ""))
+        logger.info(Constants.Credentials.oauthServerUrl + "=" + ((serviceConfig[Constants.Credentials.oauthServerUrl] as? String) ?? ""))
     }
 }

--- a/Sources/BluemixAppID/AppIDPluginConfig.swift
+++ b/Sources/BluemixAppID/AppIDPluginConfig.swift
@@ -15,7 +15,7 @@ import Foundation
 import SimpleLogger
 import SwiftyJSON
 
-internal class CredentialsPluginConfig {
+internal class AppIDPluginConfig {
 
     private let logger = Logger(forName: Constants.APIPlugin.name)
 

--- a/Sources/BluemixAppID/Constants.swift
+++ b/Sources/BluemixAppID/Constants.swift
@@ -63,4 +63,7 @@ struct Constants {
         static let attributes = "/api/v1/attributes"
         static let userInfo = "/userinfo"
     }
+
+    static let bearer = "Bearer"
+    static let authHeader = "Authorization"
 }

--- a/Sources/BluemixAppID/Constants.swift
+++ b/Sources/BluemixAppID/Constants.swift
@@ -1,0 +1,66 @@
+/*
+ Copyright 2018 IBM Corp.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+struct Constants {
+
+    struct APIPlugin {
+        static let name = "APIKituraCredentialsPlugin"
+    }
+
+    struct WebAppPlugin {
+        static let name = "WebAppKituraCredentialsPlugin"
+    }
+
+    struct VCAP {
+        static let services = "VCAP_SERVICES"
+        static let application = "VCAP_APPLICATION"
+        static let credentials = "credentials"
+        static let serviceName = "AppID"
+        static let serviceNameV1 = "AdvancedMobileAccess"
+    }
+
+    struct Credentials {
+        static let tenantId = "tenantId"
+        static let clientId = "clientId"
+        static let secret = "secret"
+        static let redirectUri = "redirectUri"
+        static let oauthServerUrl = "oauthServerUrl"
+        static let userProfileServerUrl = "profilesUrl"
+    }
+
+    struct AppID {
+        static let allowAnonymousLogin = "allowAnonymousLogin"
+        static let allowCreateNewAnonymousUser = "allowCreateNewAnonymousUser"
+        static let forceLogin = "forceLogin"
+
+        static let defaultScope = "appid_default"
+    }
+
+    struct AuthContext {
+        static let name = "APPID_AUTH_CONTEXT"
+        static let identityToken = "identityToken"
+        static let identityTokenPayload = "identityTokenPayload"
+        static let accessToken = "accessToken"
+        static let accessTokenPayload = "accessTokenPayload"
+    }
+
+    struct Endpoints {
+        static let token = "/token"
+        static let authorization = "/authorization"
+        static let publicKeys = "/publickeys"
+        static let attributes = "/api/v1/attributes"
+        static let userInfo = "/userinfo"
+    }
+}

--- a/Sources/BluemixAppID/CredentialsPlugin.swift
+++ b/Sources/BluemixAppID/CredentialsPlugin.swift
@@ -1,0 +1,93 @@
+/*
+ Copyright 2018 IBM Corp.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+import SimpleLogger
+import SwiftyJSON
+
+internal class CredentialsPluginConfig {
+
+    private let logger = Logger(forName: Constants.APIPlugin.name)
+
+    var serviceConfig: [String: Any] = [:]
+
+    var isTesting: Bool {
+        return serverUrl == "testServerUrl"
+    }
+
+    var tenantId: String? {
+        return serviceConfig[Constants.Credentials.tenantId] as? String
+    }
+
+    var clientId: String? {
+        return serviceConfig[Constants.Credentials.clientId] as? String
+    }
+
+    var secret: String? {
+        return serviceConfig[Constants.Credentials.secret] as? String
+    }
+
+    var redirectUri: String? {
+        return serviceConfig[Constants.Credentials.redirectUri] as? String
+    }
+
+    var serverUrl: String? {
+        return serviceConfig[Constants.Credentials.oauthServerUrl] as? String
+    }
+
+    var userProfileServerUrl: String? {
+        return serviceConfig[Constants.Credentials.userProfileServerUrl] as? String
+    }
+
+    public init(options: [String: Any]?) {
+
+        logger.debug("Intializing")
+
+        let options = options ?? [:]
+        let vcapString = ProcessInfo.processInfo.environment[Constants.VCAP.services] ?? ""
+        let vcapServices = JSON.parse(string: vcapString)
+        var vcapServiceCredentials: [String: Any]? = [:]
+
+        if let dict = vcapServices.dictionary {
+            for (key, value) in dict {
+                if key.hasPrefix(Constants.VCAP.serviceName) || key.hasPrefix(Constants.VCAP.serviceNameV1) {
+                    vcapServiceCredentials = (value.array?[0])?.dictionaryObject?[Constants.VCAP.credentials] as? [String : Any]
+                    break
+                }
+            }
+        }
+
+        let credentials = [Constants.Credentials.clientId,
+                           Constants.Credentials.tenantId,
+                           Constants.Credentials.secret,
+                           Constants.Credentials.oauthServerUrl,
+                           Constants.Credentials.userProfileServerUrl]
+
+        for field in credentials {
+            serviceConfig[field] = options[field] ?? vcapServiceCredentials?[field]
+        }
+
+        serviceConfig[Constants.Credentials.redirectUri] =
+            options[Constants.Credentials.redirectUri] ??
+            ProcessInfo.processInfo.environment[Constants.Credentials.redirectUri]
+
+        if serviceConfig[Constants.Credentials.redirectUri] == nil {
+            if let vcapApplication = ProcessInfo.processInfo.environment[Constants.VCAP.application] {
+                let vcapApplicationJson = JSON.parse(string: vcapApplication)
+                let applicationUris = vcapApplicationJson["application_uris"]
+                let uri = applicationUris.count > 0 ? applicationUris[0] : ""
+                serviceConfig[Constants.Credentials.redirectUri] = "https://\(uri.stringValue)/ibm/bluemix/appid/callback"
+            }
+        }
+    }
+}

--- a/Sources/BluemixAppID/UserAttributeManager.swift
+++ b/Sources/BluemixAppID/UserAttributeManager.swift
@@ -24,11 +24,11 @@ public class UserAttributeManager {
 
     private let logger = Logger(forName: "UserAttributeManager")
 
-    var serviceConfig: CredentialsPluginConfig
+    var serviceConfig: AppIDPluginConfig
 
     public init(options: [String: Any]?) {
 
-        serviceConfig = CredentialsPluginConfig(options: options)
+        serviceConfig = AppIDPluginConfig(options: options)
 
         guard serviceConfig.userProfileServerUrl != nil, serviceConfig.serverUrl != nil else {
             logger.error("Ensure your app is either bound to an App ID service instance or pass required profilesUrl parameter to the constructor")

--- a/Sources/BluemixAppID/UserAttributeManager.swift
+++ b/Sources/BluemixAppID/UserAttributeManager.swift
@@ -10,7 +10,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
- 
+
 import Foundation
 import Kitura
 import Credentials

--- a/Sources/BluemixAppID/UserAttributeManager.swift
+++ b/Sources/BluemixAppID/UserAttributeManager.swift
@@ -1,3 +1,16 @@
+/*
+ Copyright 2018 IBM Corp.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+ 
 import Foundation
 import Kitura
 import Credentials
@@ -8,31 +21,16 @@ import KituraSession
 
 @available(OSX 10.12, *)
 public class UserAttributeManager {
-    private let VcapServices = "VCAP_SERVICES"
-    private let VcapServicesCredntials = "credentials"
-    private let VcapServicesServiceName = "AdvancedMobileAccess"
-    private let UserProfileServerURL = "profilesUrl"
-    private let AttributesEndpoint = "/api/v1/attributes"
+
     private let logger = Logger(forName: "UserAttributeManager")
-    var serviceConfig: [String:Any] = [:]
 
-    public init(options:[String:Any]?) {
-        let options = options ?? [:]
-        let vcapString = ProcessInfo.processInfo.environment[VcapServices] ?? ""
-        let vcapServices = JSON.parse(string: vcapString)
-        var vcapServiceCredentials: [String:Any]? = [:]
-        if let dict = vcapServices.dictionary {
-            for (key,value) in dict {
-                if key.hasPrefix(VcapServicesServiceName) {
-                    vcapServiceCredentials = (value.array?[0])?.dictionaryObject?[VcapServicesCredntials] as? [String : Any]
-                    break
-                }
-            }
-        }
+    var serviceConfig: CredentialsPluginConfig
 
-        serviceConfig[UserProfileServerURL] = options[UserProfileServerURL] ?? vcapServiceCredentials?[UserProfileServerURL]
+    public init(options: [String: Any]?) {
 
-        guard serviceConfig[UserProfileServerURL] != nil else {
+        serviceConfig = CredentialsPluginConfig(options: options)
+
+        guard serviceConfig.userProfileServerUrl != nil, serviceConfig.serverUrl != nil else {
             logger.error("Ensure your app is either bound to an App ID service instance or pass required profilesUrl parameter to the constructor")
             return
         }
@@ -75,11 +73,13 @@ public class UserAttributeManager {
     internal func handleRequest(attributeName: String?, attributeValue: String?, method:String, accessToken: String,completionHandler: @escaping (Swift.Error?, [String:Any]?) -> Void) {
 
         self.logger.debug("UserAttributeManager :: handle Request - " + method + " " + (attributeName ?? "all"))
-        guard let profileURL = serviceConfig[UserProfileServerURL] as? String else {
+
+        guard let profileURL = serviceConfig.userProfileServerUrl else {
             completionHandler(UserAttributeError.userAttributeFailure("Failed to get UserProfileServerURL from serviceConfig as String"), nil)
             return
         }
-        var url:String = profileURL + AttributesEndpoint + "/"
+
+        var url = profileURL + Constants.Endpoints.attributes + "/"
         if let attributeName = attributeName {
             url += attributeName
         }

--- a/Sources/BluemixAppID/WebAppKituraCredentialsPlugin.swift
+++ b/Sources/BluemixAppID/WebAppKituraCredentialsPlugin.swift
@@ -247,7 +247,7 @@ extension WebAppKituraCredentialsPlugin {
               let secret = serviceConfig.secret,
               let serverUrl = serviceConfig.serverUrl else {
 
-                onFailure(HTTPStatusCode(rawValue: 400), nil)
+                onFailure(nil, nil)
                 return
         }
 

--- a/Sources/BluemixAppID/WebAppKituraCredentialsPlugin.swift
+++ b/Sources/BluemixAppID/WebAppKituraCredentialsPlugin.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 IBM Corp.
+ Copyright 2018 IBM Corp.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -23,29 +23,20 @@ import KituraSession
 @available(OSX 10.12, *)
 public class WebAppKituraCredentialsPlugin: CredentialsPluginProtocol {
 
-    public static let Name = "appid-webapp-kitura-credentials-plugin"
-    public static let AllowAnonymousLogin = "allowAnonymousLogin"
-    public static let AllowCreateNewAnonymousUser = "allowCreateNewAnonymousUser"
-    public static let ForceLogin = "forceLogin"
-    public static let AuthContext = "APPID_AUTH_CONTEXT"
-
-    private let defaultScope = "appid_default"
-    private let authorizationPath = "/authorization"
-    private let tokenPath = "/token"
     private let serviceConfig: WebAppKituraCredentialsPluginConfig
 
-    private let logger = Logger(forName: "WebAppKituraCredentialsPlugin")
+    private let logger = Logger(forName: Constants.WebAppPlugin.name)
 
     public let redirecting = true
 
     public var usersCache: NSCache<NSString, BaseCacheElement>?
 
     public var name: String {
-        return WebAppKituraCredentialsPlugin.Name
+        return Constants.WebAppPlugin.name
     }
 
     public init(options: [String: Any]?) {
-        logger.debug("Initializing WebAppKituraCredentialsPlugin")
+        logger.debug("Initializing " + Constants.WebAppPlugin.name)
         self.serviceConfig = WebAppKituraCredentialsPluginConfig(options: options)
     }
 
@@ -81,7 +72,7 @@ public class WebAppKituraCredentialsPlugin: CredentialsPluginProtocol {
 
     public func logout(request: RouterRequest) {
         //        request.session?.remove(key: OriginalUrl)
-        request.session?.remove(key: WebAppKituraCredentialsPlugin.AuthContext)
+        request.session?.remove(key: Constants.AuthContext.name)
     }
 
 }
@@ -134,9 +125,9 @@ extension WebAppKituraCredentialsPlugin {
                                       inProgress: @escaping () -> Void) {
 
         logger.debug("WebAppKituraCredentialsPlugin :: handleAuthorization")
-        let forceLogin: Bool = options[WebAppKituraCredentialsPlugin.ForceLogin] as? Bool ?? false
-        let allowAnonymousLogin: Bool = options[WebAppKituraCredentialsPlugin.AllowAnonymousLogin] as? Bool ?? false
-        let allowCreateNewAnonymousUser: Bool = options[WebAppKituraCredentialsPlugin.AllowCreateNewAnonymousUser] as? Bool ?? true
+        let forceLogin: Bool = options[Constants.AppID.forceLogin] as? Bool ?? false
+        let allowAnonymousLogin: Bool = options[Constants.AppID.allowAnonymousLogin] as? Bool ?? false
+        let allowCreateNewAnonymousUser: Bool = options[Constants.AppID.allowCreateNewAnonymousUser] as? Bool ?? true
         // If user is already authenticated and new login is not enforced - end processing
         // Otherwise - persist original request url and redirect to authorization
         if let requestUserProfile = request.userProfile, !forceLogin && !allowAnonymousLogin {
@@ -159,7 +150,7 @@ extension WebAppKituraCredentialsPlugin {
         var authUrl = generateAuthorizationUrl(options: options)
 
         // If there's an existing anonymous access token on session - add it to the request url
-        if let appIdAuthContext = request.session?[WebAppKituraCredentialsPlugin.AuthContext] as? [String : Any] {
+        if let appIdAuthContext = request.session?[Constants.AuthContext.name] as? [String : Any] {
             let payload = appIdAuthContext["accessTokenPayload"] as? [String : Any]
             if (payload?["amr"] as? [String])?[0] ==  "appid_anon" {
                 logger.debug("WebAppKituraCredentialsPlugin :: handleAuthorization :: added anonymous access_token to url")
@@ -238,7 +229,7 @@ extension WebAppKituraCredentialsPlugin {
             }
         }
 
-        originalRequest.session?[WebAppKituraCredentialsPlugin.AuthContext] = appIdAuthorizationContext
+        originalRequest.session?[Constants.AuthContext.name] = appIdAuthorizationContext
 
         let userProfile = UserProfile(id: kituraUserId, displayName: kituraDisplayName, provider: kituraProvider)
         onSuccess(userProfile)
@@ -251,11 +242,16 @@ extension WebAppKituraCredentialsPlugin {
                                 request: RouterRequest,
                                 onSuccess: @escaping (UserProfile) -> Void) {
         logger.debug("WebAppKituraCredentialsPlugin :: retrieveTokens")
-        let serviceConfig = self.serviceConfig
 
-        let clientId = serviceConfig.clientId
-        let secret = serviceConfig.secret
-        let tokenEndpoint = serviceConfig.oAuthServerUrl + tokenPath
+        guard let clientId = serviceConfig.clientId,
+              let secret = serviceConfig.secret,
+              let serverUrl = serviceConfig.serverUrl else {
+
+                onFailure(HTTPStatusCode(rawValue: 400), nil)
+                return
+        }
+
+        let tokenEndpoint = serverUrl + Constants.Endpoints.token
         let redirectUri = serviceConfig.redirectUri
         let authorization = clientId + ":" + secret
 
@@ -288,16 +284,15 @@ extension WebAppKituraCredentialsPlugin {
     }
 
     fileprivate func generateAuthorizationUrl(options: [String:Any]) -> String {
-        let serviceConfig = self.serviceConfig
-        let clientId = serviceConfig.clientId
+
         var scopeAddition: String?
         if let addition = options["scope"] as? String {
             scopeAddition = " " + addition
         }
-        let scope = defaultScope + (scopeAddition ?? "")
-        let authorizationEndpoint = serviceConfig.oAuthServerUrl + authorizationPath
-        let redirectUri = serviceConfig.redirectUri
-        var query = "client_id=\(clientId)&response_type=code&redirect_uri=\(redirectUri)&scope=\(scope)"
+
+        let scope = Constants.AppID.defaultScope + (scopeAddition ?? "")
+        let authorizationEndpoint = (serviceConfig.serverUrl ?? "") + Constants.Endpoints.authorization
+        var query = "client_id=\(serviceConfig.clientId ?? "")&response_type=code&redirect_uri=\(serviceConfig.redirectUri ?? "")&scope=\(scope)"
         if (options["allowAnonymousLogin"] as? Bool) == true {
             query += "&idp=appid_anon"
         }

--- a/Sources/BluemixAppID/WebAppKituraCredentialsPluginConfig.swift
+++ b/Sources/BluemixAppID/WebAppKituraCredentialsPluginConfig.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 IBM Corp.
+ Copyright 2018 IBM Corp.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -14,84 +14,21 @@ import Foundation
 import SwiftyJSON
 import SimpleLogger
 
-internal class WebAppKituraCredentialsPluginConfig {
+internal class WebAppKituraCredentialsPluginConfig: CredentialsPluginConfig {
 
-    private let VCAP_SERVICES = "VCAP_SERVICES"
-    private let VCAP_SERVICES_CREDENTIALS = "credentials"
-    private let VCAP_SERVICES_SERVICE_NAME = "AdvancedMobileAccess"
-    private let VCAP_SERVICES_SERVICE_NAME2 = "AppID"
-    private let VCAP_APPLICATION = "VCAP_APPLICATION"
-    private let TENANT_ID = "tenantId"
-    private let CLIENT_ID = "clientId"
-    private let SECRET = "secret"
-    private let REDIRECT_URI = "redirectUri"
-    private let OAUTH_SERVER_URL = "oauthServerUrl"
+	private let logger = Logger(forName: Constants.WebAppPlugin.name)
 
-	private let logger = Logger(forName: "WebAppKituraCredentialsPlugin")
+    override init(options: [String: Any]?) {
+        super.init(options: options)
 
-    var serviceConfig: [String: Any] = [:]
+        guard tenantId != nil, clientId != nil, secret != nil, serverUrl != nil, redirectUri != nil else {
 
-    var config: [String: Any] {
-        return serviceConfig
-    }
+            logger.error("Failed to initialize WebAppKituraCredentialsPluginConfig." +
+                         " All requests to protected endpoints will be rejected." +
+                         " Ensure your app is either bound to an App ID service instance" +
+                         " or pass required parameters in the strategy constructor")
 
-    var tenantId: String {
-        return serviceConfig[TENANT_ID] as? String ?? ""
-    }
-
-    var clientId: String {
-        return serviceConfig[CLIENT_ID] as? String ?? ""
-    }
-
-    var secret: String {
-        return serviceConfig[SECRET] as? String ?? ""
-    }
-
-    var oAuthServerUrl: String {
-        return serviceConfig[OAUTH_SERVER_URL] as? String ?? ""
-    }
-    var redirectUri: String {
-        return serviceConfig[REDIRECT_URI] as? String ?? ""
-    }
-
-    public init(options: [String: Any]?) {
-        let options = options ?? [:]
-        let vcapString = ProcessInfo.processInfo.environment[VCAP_SERVICES] ?? ""
-        let vcapServices = JSON.parse(string: vcapString)
-        var vcapServiceCredentials: [String:Any]? = [:]
-        if let dict = vcapServices.dictionary {
-            for (key, value) in dict {
-                if key.hasPrefix(VCAP_SERVICES_SERVICE_NAME)||key.hasPrefix(VCAP_SERVICES_SERVICE_NAME2) {
-                    vcapServiceCredentials = (value.array?[0])?.dictionaryObject?[VCAP_SERVICES_CREDENTIALS] as? [String: Any]
-                    break
-                }
-            }
+                return
         }
-
-        serviceConfig[TENANT_ID] = options[TENANT_ID] ?? vcapServiceCredentials?[TENANT_ID]
-        serviceConfig[CLIENT_ID] = options[CLIENT_ID] ?? vcapServiceCredentials?[CLIENT_ID]
-        serviceConfig[SECRET] = options[SECRET] ?? vcapServiceCredentials?[SECRET]
-        serviceConfig[OAUTH_SERVER_URL] = options[OAUTH_SERVER_URL] ?? vcapServiceCredentials?[OAUTH_SERVER_URL]
-
-        serviceConfig[REDIRECT_URI] = options[REDIRECT_URI] ?? ProcessInfo.processInfo.environment[REDIRECT_URI]
-
-        if serviceConfig[REDIRECT_URI] == nil {
-            if let vcapApplication = ProcessInfo.processInfo.environment[VCAP_APPLICATION] {
-                let vcapApplicationJson = JSON.parse(string: vcapApplication)
-				let applicationUris = vcapApplicationJson["application_uris"]
-				let uri = applicationUris.count > 0 ? applicationUris[0] : ""
-                serviceConfig[REDIRECT_URI] = "https://\(uri.stringValue)/ibm/bluemix/appid/callback"
-            }
-        }
-
-        guard serviceConfig[CLIENT_ID] != nil && serviceConfig[SECRET] != nil &&
-              serviceConfig[OAUTH_SERVER_URL] != nil && serviceConfig[TENANT_ID] != nil &&
-              serviceConfig[REDIRECT_URI] != nil else {
-            logger.error("Failed to initialize WebAppKituraCredentialsPluginConfig. All requests to protected endpoints will be rejected")
-            logger.error("Ensure your app is either bound to an App ID service instance or pass required parameters in the strategy constructor")
-            return
-        }
-
     }
-
 }

--- a/Sources/BluemixAppID/WebAppKituraCredentialsPluginConfig.swift
+++ b/Sources/BluemixAppID/WebAppKituraCredentialsPluginConfig.swift
@@ -14,7 +14,7 @@ import Foundation
 import SwiftyJSON
 import SimpleLogger
 
-internal class WebAppKituraCredentialsPluginConfig: CredentialsPluginConfig {
+internal class WebAppKituraCredentialsPluginConfig: AppIDPluginConfig {
 
 	private let logger = Logger(forName: Constants.WebAppPlugin.name)
 

--- a/Tests/BluemixAppIDTests/ApiPluginTest.swift
+++ b/Tests/BluemixAppIDTests/ApiPluginTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 IBM Corp.
+ Copyright 2018 IBM Corp.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -39,9 +39,10 @@ class ApiPluginTest: XCTestCase {
 
     func testApiConfig() {
         unsetenv("VCAP_SERVICES")
+        unsetenv("redirectUri")
         var config = APIKituraCredentialsPluginConfig(options:[:])
         XCTAssertEqual(config.serviceConfig.count, 0)
-        XCTAssertNil(config.serverUrl)
+        XCTAssertEqual(config.serverUrl, nil)
         config = APIKituraCredentialsPluginConfig(options: ["oauthServerUrl": "someurl"])
         XCTAssertEqual(config.serverUrl, "someurl")
 

--- a/Tests/BluemixAppIDTests/UserAttributesManagerTest.swift
+++ b/Tests/BluemixAppIDTests/UserAttributesManagerTest.swift
@@ -1,5 +1,5 @@
 /*
- Copyright 2017 IBM Corp.
+ Copyright 2018 IBM Corp.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -110,17 +110,17 @@ class UserAttributesManagerTest: XCTestCase {
     func testInit() {
 
         // check failure - profileUrl was not provided neither trought VCAP nor options
-        XCTAssertNil(MockUserAttributeManger.init(options: [:]).serviceConfig["profilesUrl"])
+        XCTAssertNil(MockUserAttributeManger.init(options: [:]).serviceConfig.userProfileServerUrl)
 
         // check success - profileUrl was provided trought VCAP
         unsetenv("VCAP_SERVICES")
         unsetenv("VCAP_APPLICATION")
         setenv("VCAP_SERVICES", "{\n  \"AdvancedMobileAccess\": [\n    {\n      \"credentials\": {\n        \"clientId\": \"vcapclient\",\n        \"secret\": \"vcapsecret\",\n        \"tenantId\": \"vcaptenant\",\n        \"oauthServerUrl\": \"vcapserver\",\n \"profilesUrl\": \"vcapprofile\"\n     }\n    }\n  ]\n}", 1)
         userAttManager = MockUserAttributeManger.init(options: [:])
-        XCTAssertNotNil(userAttManager?.serviceConfig["profilesUrl"])
+        XCTAssertNotNil(userAttManager?.serviceConfig.userProfileServerUrl)
 
         // check success - profileUrl was provided trought options
-        XCTAssertNotNil(MockUserAttributeManger.init(options: fullOptions).serviceConfig["profilesUrl"])
+        XCTAssertNotNil(MockUserAttributeManger.init(options: fullOptions).serviceConfig.userProfileServerUrl)
     }
 
     func testSetAttribute() {


### PR DESCRIPTION
Our WebStrategy and ApiStrategy share a significant amount of code related to parsing VCAP services fields. 

We can merge that logic into a super class to reduce code duplication and simplify VCAP changes in the future. Also, moves redundant constants into a constants file.