### PR TITLE
Fix Request Error Name-spacing

### DIFF
--- a/Sources/BluemixAppID/UserProfileManager.swift
+++ b/Sources/BluemixAppID/UserProfileManager.swift
@@ -77,7 +77,7 @@ public class UserProfileManager {
         self.logger.debug("UserProfileManager :: handle Request - User Info")
 
         guard let url = serviceConfig.serverUrl else {
-            completionHandler(RequestError.invalidOauthServerUrl, nil)
+            completionHandler(AppIDRequestError.invalidOauthServerUrl, nil)
             return
         }
 
@@ -85,13 +85,13 @@ public class UserProfileManager {
 
             guard error == nil, let userInfo = userInfo else {
                 self.logger.debug("Error: Unexpected error while retrieving User Info. Msg: \(error?.localizedDescription ?? "")")
-                return completionHandler(error ?? RequestError.unexpectedError, nil)
+                return completionHandler(error ?? AppIDRequestError.unexpectedError, nil)
             }
 
             // Validate userinfo response has subject field
             guard let subject = userInfo["sub"] as? String else {
                 self.logger.error("Error: Invalid response user info response must contain the subject field.")
-                return completionHandler(error ?? RequestError.unexpectedError, nil)
+                return completionHandler(error ?? AppIDRequestError.unexpectedError, nil)
             }
 
             if let identityToken = identityToken {
@@ -116,7 +116,7 @@ public class UserProfileManager {
         self.logger.debug("UserProfileManager :: handle Request - " + method + " " + (attributeName ?? "all"))
 
         guard let profileURL = serviceConfig.userProfileServerUrl else {
-            completionHandler(RequestError.invalidProfileServerUrl, nil)
+            completionHandler(AppIDRequestError.invalidProfileServerUrl, nil)
             return
         }
 
@@ -133,10 +133,10 @@ public class UserProfileManager {
         let request = HTTP.request(url) {response in
             if response?.status == 401 || response?.status == 403 {
                 self.logger.error("Unauthorized")
-                completionHandler(RequestError.unauthorized, nil)
+                completionHandler(AppIDRequestError.unauthorized, nil)
             } else if response?.status == 404 {
                 self.logger.error("Not found")
-                completionHandler(RequestError.notFound, nil)
+                completionHandler(AppIDRequestError.notFound, nil)
             } else if let responseStatus = response?.status, responseStatus >= 200 && responseStatus < 300 {
                 var responseJson: [String: Any] = [:]
                 do {
@@ -145,11 +145,11 @@ public class UserProfileManager {
                     }
                     completionHandler(nil, responseJson)
                 } catch _ {
-                    completionHandler(RequestError.parsingError, nil)
+                    completionHandler(AppIDRequestError.parsingError, nil)
                 }
             } else {
                 self.logger.error("Unexpected error")
-                completionHandler(RequestError.unexpectedError, nil)
+                completionHandler(AppIDRequestError.unexpectedError, nil)
             }
         }
 

--- a/Sources/BluemixAppID/UserProfileManagerError.swift
+++ b/Sources/BluemixAppID/UserProfileManagerError.swift
@@ -18,7 +18,7 @@ public enum UserProfileError: Error {
     case conflictingSubjects
     case userAttributeFailure(String)
 
-    var description: String {
+    public var description: String {
         switch self {
         case .invalidIdentityToken: return "Invalid Identity Token"
         case .invalidUserInfoResponse: return "Invalid User Info Response"
@@ -28,7 +28,7 @@ public enum UserProfileError: Error {
     }
 }
 
-public enum RequestError: Error {
+public enum AppIDRequestError: Error {
     case unauthorized
     case notFound
     case parsingError
@@ -36,7 +36,7 @@ public enum RequestError: Error {
     case invalidOauthServerUrl
     case invalidProfileServerUrl
 
-    var description: String {
+    public var description: String {
         switch self {
         case .unauthorized: return "Unauthorized"
         case .notFound: return "Not Found"

--- a/Tests/BluemixAppIDTests/UserProfileManagerTests.swift
+++ b/Tests/BluemixAppIDTests/UserProfileManagerTests.swift
@@ -48,19 +48,19 @@ class UserProfileManagerTests: XCTestCase {
 
         override func handleRequest(accessToken: String, url: String, method: String, body: String?,completionHandler: @escaping (Swift.Error?, [String:Any]?) -> Void) {
             if accessToken.range(of:"return_error") != nil {
-                completionHandler(RequestError.unexpectedError, nil)
+                completionHandler(AppIDRequestError.unexpectedError, nil)
             }
             else if accessToken.range(of:"return_code") != nil {
                 if let statusCode = Int(accessToken.components(separatedBy: "_")[2]) {
                     switch statusCode {
                     case 401,403:
-                        completionHandler(RequestError.unauthorized, nil)
+                        completionHandler(AppIDRequestError.unauthorized, nil)
                         break
                     case 404:
-                        completionHandler(RequestError.notFound, nil)
+                        completionHandler(AppIDRequestError.notFound, nil)
                         break
                     default:
-                        completionHandler(RequestError.unexpectedError, nil)
+                        completionHandler(AppIDRequestError.unexpectedError, nil)
                     }
                 }
             }
@@ -119,7 +119,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unexpected error"
         userProfileManager.setAttribute(accessToken : AccessTokenFailure, attributeName : "name", attributeValue : "abc", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, RequestError.unexpectedError)
+                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, AppIDRequestError.unexpectedError)
             } else {
                 self.setOnSuccess()
             }
@@ -128,7 +128,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 401"
         userProfileManager.setAttribute(accessToken : AccessTokenStatusCode401, attributeName : "name", attributeValue : "abc", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -137,7 +137,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 403"
         userProfileManager.setAttribute(accessToken : AccessTokenStatusCode403, attributeName : "name", attributeValue : "abc", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -146,7 +146,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Not found 404"
         userProfileManager.setAttribute(accessToken : AccessTokenStatusCode404, attributeName : "name", attributeValue : "abc", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, RequestError.notFound)
+                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, AppIDRequestError.notFound)
             } else {
                 self.setOnSuccess()
             }
@@ -173,7 +173,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unexpected error"
         userProfileManager.getAttribute(accessToken : AccessTokenFailure, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, RequestError.unexpectedError)
+                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, AppIDRequestError.unexpectedError)
             } else {
                 self.setOnSuccess()
             }
@@ -182,7 +182,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 401"
         userProfileManager.getAttribute(accessToken : AccessTokenStatusCode401, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -191,7 +191,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 403"
         userProfileManager.getAttribute(accessToken : AccessTokenStatusCode403, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -200,7 +200,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Not found 404"
         userProfileManager.getAttribute(accessToken : AccessTokenStatusCode404, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, RequestError.notFound)
+                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, AppIDRequestError.notFound)
             } else {
                 self.setOnSuccess()
             }
@@ -229,7 +229,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unexpected error"
         userProfileManager.deleteAttribute(accessToken : AccessTokenFailure, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, RequestError.unexpectedError)
+                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, AppIDRequestError.unexpectedError)
             } else {
                 self.setOnSuccess()
             }
@@ -238,7 +238,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 401"
         userProfileManager.deleteAttribute(accessToken : AccessTokenStatusCode401, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -248,7 +248,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 403"
         userProfileManager.deleteAttribute(accessToken : AccessTokenStatusCode403, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -257,7 +257,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Not found 404"
         userProfileManager.deleteAttribute(accessToken : AccessTokenStatusCode404, attributeName : "name", completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, RequestError.notFound)
+                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, AppIDRequestError.notFound)
             } else {
                 self.setOnSuccess()
             }
@@ -284,7 +284,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unexpected error"
         userProfileManager.getAllAttributes(accessToken : AccessTokenFailure, completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, RequestError.unexpectedError)
+                self.setOnFailure(expectation: self.expectation(description: "Unexpected error"), error: error, AppIDRequestError.unexpectedError)
             } else {
                 self.setOnSuccess()
             }
@@ -293,7 +293,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 401"
         userProfileManager.getAllAttributes(accessToken : AccessTokenStatusCode401, completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -302,7 +302,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Unauthorized 403"
         userProfileManager.getAllAttributes(accessToken : AccessTokenStatusCode403, completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, RequestError.unauthorized)
+                self.setOnFailure(expectation: self.expectation(description: "Unauthorized"), error: error, AppIDRequestError.unauthorized)
             } else {
                 self.setOnSuccess()
             }
@@ -311,7 +311,7 @@ class UserProfileManagerTests: XCTestCase {
         // expired accessToken - should fail "Not found 404"
         userProfileManager.getAllAttributes(accessToken : AccessTokenStatusCode404, completionHandler : { (err, res) in
             if let error = err {
-                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, RequestError.notFound)
+                self.setOnFailure(expectation: self.expectation(description: "Not found"), error: error, AppIDRequestError.notFound)
             } else {
                 self.setOnSuccess()
             }
@@ -349,21 +349,21 @@ class UserProfileManagerTests: XCTestCase {
 
     func testUserInfo401() {
         userProfileManager.getUserInfo(accessToken: AccessTokenStatusCode401,
-                                    completionHandler: errorHandler(RequestError.unauthorized))
+                                    completionHandler: errorHandler(AppIDRequestError.unauthorized))
         awaitExpectation()
     }
 
     func testUserInfo403() {
         userProfileManager.getUserInfo(accessToken: AccessTokenStatusCode403,
                                     identityToken: nil,
-                                    completionHandler: errorHandler(RequestError.unauthorized))
+                                    completionHandler: errorHandler(AppIDRequestError.unauthorized))
         awaitExpectation()
     }
 
     func testUserInfo404() {
         userProfileManager.getUserInfo(accessToken: AccessTokenStatusCode404,
                                     identityToken: nil,
-                                    completionHandler: errorHandler(RequestError.notFound))
+                                    completionHandler: errorHandler(AppIDRequestError.notFound))
         awaitExpectation()
     }
 
@@ -397,7 +397,7 @@ class UserProfileManagerTests: XCTestCase {
         return errorHandler(_: expected.description)
     }
 
-    func errorHandler(_ expected: RequestError) -> (Swift.Error?, [String: Any]?) -> Void {
+    func errorHandler(_ expected: AppIDRequestError) -> (Swift.Error?, [String: Any]?) -> Void {
         return errorHandler(_: expected.description)
     }
 
@@ -412,7 +412,7 @@ class UserProfileManagerTests: XCTestCase {
         }
     }
 
-    func setOnFailure(expectation: XCTestExpectation? = nil, error: Swift.Error? = nil,_ expectedMsg: RequestError) {
+    func setOnFailure(expectation: XCTestExpectation? = nil, error: Swift.Error? = nil,_ expectedMsg: AppIDRequestError) {
         setOnFailure(expectation: expectation, error: error, expectedMsg.description)
     }
 
@@ -420,7 +420,7 @@ class UserProfileManagerTests: XCTestCase {
         if let fulfillExpectation = expectation {
             if let error = error as? UserProfileError {
                 XCTAssertEqual(error.description, expectedMsg)
-            } else if let error = error as? RequestError {
+            } else if let error = error as? AppIDRequestError {
                 XCTAssertEqual(error.description, expectedMsg)
             } else {
                 XCTAssert(error.debugDescription.range(of: expectedMsg) != nil)


### PR DESCRIPTION
Kitura introduced a type-alias on KituraContracts' RequestError type. This causes conflicts with our request error field.