### PR TITLE
Docs: updated AppID README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,17 +127,28 @@ router.get(LOGOUT_URL, handler:  { (request, response, next) in
 	_ = try? response.redirect(LANDING_PAGE_URL)
 })
 
-// Protected area
+// Protected area using `Credentials` standard `userProfile`
 router.get("/protected", handler: kituraCredentials.authenticate(credentialsType: webappKituraCredentialsPlugin.name), { (request, response, next) in
-    let appIdAuthContext:JSON? = request.session?[WebAppKituraCredentialsPlugin.AuthContext]
-    let identityTokenPayload:JSON? = appIdAuthContext?["identityTokenPayload"]
-
-    guard appIdAuthContext?.dictionary != nil, identityTokenPayload?.dictionary != nil else {
+    // check user profile for successful login
+    guard let user = request.userProfile else {
         response.status(.unauthorized)
         return next()
     }
+    try response.send("Hello \(user.displayName)")
+    next()
+})
 
-    response.send(json: identityTokenPayload!)
+// Protected area using AppID `userIdentity`
+router.get("/protected", handler: kituraCredentials.authenticate(credentialsType: webappKituraCredentialsPlugin.name), { (request, response, next) in
+    guard let authContextDict = request.session?["APPID_AUTH_CONTEXT"] as? [String: Any],
+          let identityTokenPayload = authContextDict["identityTokenPayload"] as? [String: Any],
+          let identityTokenData = try? JSONSerialization.data(withJSONObject: identityTokenPayload, options: [])
+    else {
+        response.status(.unauthorized)
+        return next()
+    }
+    let authContext = AuthorizationContext(idTokenPayload: JSON(data: identityTokenData))
+    response.send("Hello \(authContext.userIdentity.displayName)")
     next()
 })
 


### PR DESCRIPTION
In AppID 5 `WebAppKituraCredentialsPlugin.AuthContext` was replaced with the internal Constants class. The new Kitura-Sessions also returns a String:Any instead of a SwiftyJSON. 
This means that the example for AppID doesn't compile. 

This PR replaces the current example with a working example to create an `AuthorizationContext` containing the users Data.

It also adds a simpler example using Credentials `userProfile` however this only has the ID and username.

Both these routes were tested In the Kitura-Sample application using a live AppId service.