### PR TITLE
Fix: Added encoders/decoders to tests

### DIFF
--- a/Tests/IBMCloudAppIDTests/ApiPluginTests.swift
+++ b/Tests/IBMCloudAppIDTests/ApiPluginTests.swift
@@ -69,8 +69,8 @@ class ApiPluginTests: XCTestCase {
         httpRequest =  HTTPServerRequest(socket: try! Socket.create(family: .inet), httpParser: parser)
         httpResponse = HTTPServerResponse(processor: IncomingHTTPSocketProcessor(socket: try! Socket.create(family: .inet), using: delegate(), keepalive: .disabled), request: httpRequest)
         routerStack = Stack<Router>()
-        request = RouterRequest(request: httpRequest)
-        response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request)
+        request = RouterRequest(request: httpRequest, decoder: JSONDecoder())
+        response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request, encoders: [.json: { return JSONEncoder() }], defaultResponseMediaType: .json)
     }
 
     func testAuthFlowNoAuthHeader() {

--- a/Tests/IBMCloudAppIDTests/WebAppPluginTest.swift
+++ b/Tests/IBMCloudAppIDTests/WebAppPluginTest.swift
@@ -65,7 +65,7 @@ class WebAppPluginTest: XCTestCase {
 
         let web = MockWebAppKituraCredentialsPlugin(options: TestConstants.options)
         let httpRequest =  HTTPServerRequest(socket: try! Socket.create(family: .inet), httpParser: nil)
-        let request = RouterRequest(request: httpRequest)
+        let request = RouterRequest(request: httpRequest, decoder: JSONDecoder())
         request.session = SessionState(id: "someSession", store: InMemoryStore())
         XCTAssertNil(request.session?[Constants.AuthContext.name] as? [String:Any])
 
@@ -506,7 +506,7 @@ extension WebAppPluginTest {
 
         public init(request: HTTPServerRequest, url: String) {
             self.urlTest = url
-            super.init(request: request)
+            super.init(request: request, decoder: JSONDecoder())
         }
         public override var urlURL: URL {
             return URL(string:urlTest)!
@@ -524,7 +524,7 @@ extension WebAppPluginTest {
             self.expectation = expectation
             self.redirectUri = redirectUri
             routerStack.push(Router())
-            super.init(response: response, routerStack: routerStack, request: request)
+            super.init(response: response, routerStack: routerStack, request: request, encoders: [.json: { return JSONEncoder() }], defaultResponseMediaType: .json)
         }
         public override func redirect(_ path: String, status: HTTPStatusCode = .movedTemporarily) -> RouterResponse {
             if let expectation = expectation {
@@ -535,8 +535,8 @@ extension WebAppPluginTest {
             }
             let httpRequest =  HTTPServerRequest(socket: try! Socket.create(family: .inet), httpParser: nil)
             let httpResponse = HTTPServerResponse(processor: IncomingHTTPSocketProcessor(socket: try! Socket.create(family: .inet), using: delegate(), keepalive: .disabled), request: httpRequest)
-            let request = RouterRequest(request: httpRequest)
-            let response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request)
+            let request = RouterRequest(request: httpRequest, decoder: JSONDecoder())
+            let response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request, encoders: [.json: { return JSONEncoder() }], defaultResponseMediaType: .json)
             return response
         }
     }
@@ -566,8 +566,8 @@ extension WebAppPluginTest {
                                                    request: httpRequest)
             routerStack.push(Router())
 
-            request = RouterRequest(request: httpRequest)
-            response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request)
+            request = RouterRequest(request: httpRequest, decoder: JSONDecoder())
+            response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request, encoders: [.json: { return JSONEncoder() }], defaultResponseMediaType: .json)
         }
 
         func expectFailure(with expect: XCTestExpectation) {
@@ -588,7 +588,7 @@ extension WebAppPluginTest {
 
         func mockRequest(url: String) {
             request = MockRouterRequest(request: httpRequest, url: url)
-            response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request)
+            response = RouterResponse(response: httpResponse, routerStack: routerStack, request: request, encoders: [.json: { return JSONEncoder() }], defaultResponseMediaType: .json)
         }
 
         func mockResponse(redirectUri: String, expectation: XCTestExpectation? = nil) {


### PR DESCRIPTION
In Kitura 2.5 changed were made to RouterRequest and RouterResponse internal initialisers.
Since the App-id tests import Kitura as a testable dependency they use these initialisers and so the tests have broken.

This PR adds JSON encoders and Decoders so that the tests can compile and run.