### PR TITLE
fix: Added import dispatch

### DIFF
--- a/Sources/IBMCloudAppID/PublicKeysUtil.swift
+++ b/Sources/IBMCloudAppID/PublicKeysUtil.swift
@@ -15,6 +15,7 @@ import SimpleLogger
 import SwiftyRequest
 import SwiftJWKtoPEM
 import Foundation
+import Dispatch
 
 /// Public Key utility class.
 /// - Responsible for retrieving and storing App ID public keys

--- a/Tests/IBMCloudAppIDTests/ApiPluginTests.swift
+++ b/Tests/IBMCloudAppIDTests/ApiPluginTests.swift
@@ -19,6 +19,7 @@ import Credentials
 import Socket
 import SwiftyJSON
 import Foundation
+import Dispatch
 @testable import IBMCloudAppID
 
 @available(OSX 10.12, *)


### PR DESCRIPTION
These two files use DispatchQueue. This is brought in with Foundation for mac however for swift 4.0 on linux you need to specify `import Dispatch`.

This PR adds the import statements so that this repo will compile for swift 4.0 on Linux.