### PR TITLE
Feat: Remove requirement for Linker flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run -i -t -v ${TRAVIS_BUILD_DIR}:/root/repo ibmcom/swift-ubuntu-xenial /bin/bash -c "cd /root/repo; swift test"; fi # test project
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift package clean; fi  # clean built artifacts if present
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift package fetch; fi  # clones all dependencies
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift build -Xlinker -L/usr/local/opt/openssl/lib -Xcc -I/usr/local/opt/openssl/include; fi # build project
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift test -Xlinker -L/usr/local/opt/openssl/lib -Xcc -I/usr/local/opt/openssl/include; fi #run tests
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift build; fi # build project
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then swift test; fi #run tests
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       gem install slather;
-      swift package generate-xcodeproj --xcconfig-overrides openssl.xcconfig;
+      swift package generate-xcodeproj;
       slather setup IBMCloudAppID.xcodeproj;
       xcodebuild -project IBMCloudAppID.xcodeproj -scheme IBMCloudAppID build;
       xcodebuild -project IBMCloudAppID.xcodeproj -scheme IBMCloudAppID -enableCodeCoverage YES test;

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
       .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.1.0"),
       .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "1.0.1"),
       .package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", .upToNextMinor(from: "0.5.0")),
-      .package(url: "https://github.com/ibm-cloud-security/Swift-JWT-to-PEM.git", from: "0.2.0"),
+      .package(url: "https://github.com/ibm-cloud-security/Swift-JWT-to-PEM.git", from: "0.2.1"),
       .package(url: "https://github.com/IBM-Swift/BlueRSA.git", from: "1.0.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
       .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.1.0"),
       .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "1.0.1"),
       .package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", .upToNextMinor(from: "0.5.0")),
-      .package(url: "https://github.com/ibm-cloud-security/Swift-JWT-to-PEM.git", from: "0.2.1"),
+      .package(url: "https://github.com/ibm-cloud-security/Swift-JWK-to-PEM.git", from: "0.3.0"),
       .package(url: "https://github.com/IBM-Swift/BlueRSA.git", from: "1.0.0")
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -34,23 +34,6 @@ Read the [official documentation](https://console.bluemix.net/docs/services/appi
 * Kitura 2.3
 * OpenSSL
 
-### Build Instructions
-
-
-Since this library uses OpenSSL under the covers (specifically used by `Swift-JWT-to-PEM` dependency library), it requires explicitly passing build and linker paths for the OpenSSL library. Additionally, `swift package generate-xcodeproj` doesn't add the proper flags when they are passed in using the flags, therefore they must be added to the generated xcode project.
-```
-swift build -Xlinker -L/usr/local/opt/openssl/lib -Xcc -I/usr/local/opt/openssl/include
-```
-
-To generate Xcode project:
-```
-swift package generate-xcodeproj --xcconfig-overrides openssl.xcconfig
-```
-The extra xcconfig are needed to be able to build in Xcode or use `xcodebuild`.
-
-**These extra flags are necessary for any target that uses `IBMCloudAppID` library as a dependency.**
-
-
 ### Installation
 ```swift
 import PackageDescription
@@ -58,7 +41,7 @@ import PackageDescription
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/ibm-cloud-security/appid-serversdk-swift.git", .upToNextMinor(from: "4.1.0"))
+        .package(url: "https://github.com/ibm-cloud-security/appid-serversdk-swift.git", .upToNextMinor(from: "5.0.0"))
     ]
     .target(
         name: "<Your Target>",

--- a/openssl.xcconfig
+++ b/openssl.xcconfig
@@ -1,2 +1,0 @@
-HEADER_SEARCH_PATHS = /usr/local/opt/openssl/include 
-LIBRARY_SEARCH_PATHS = /usr/local/opt/openssl/lib


### PR DESCRIPTION
This PR updates the version of Swift-JWT-to-PEM.git to 0.2.1. 
This makes this repo pull in https://github.com/IBM-Swift/OpenSSL-OSX 0.5.0 which no longer requires linker flags.
I have updated travis and the README to reflect this change.