### PR TITLE
Replace SimpleLogger with LoggerAPI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
       .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "3.1.0"),
       .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.1.0"),
       .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "1.0.1"),
-      .package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", .upToNextMinor(from: "0.5.0")),
+      .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.0"),
       .package(url: "https://github.com/ibm-cloud-security/Swift-JWT-to-PEM.git", from: "0.2.0"),
       .package(url: "https://github.com/IBM-Swift/BlueRSA.git", from: "1.0.0")
     ],
@@ -37,7 +37,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "IBMCloudAppID",
-            dependencies: ["Credentials", "SwiftyRequest", "SimpleLogger", "SwiftyJSON", "KituraSession", "SwiftJWKtoPEM", "CryptorRSA"]
+            dependencies: ["Credentials", "SwiftyRequest", "LoggerAPI", "SwiftyJSON", "KituraSession", "SwiftJWKtoPEM", "CryptorRSA"]
         ),
         .testTarget(
             name: "IBMCloudAppIDTests",

--- a/Sources/IBMCloudAppID/APIKituraCredentialsPlugin.swift
+++ b/Sources/IBMCloudAppID/APIKituraCredentialsPlugin.swift
@@ -15,7 +15,7 @@ import Foundation
 import Kitura
 import KituraNet
 import Credentials
-import SimpleLogger
+import LoggerAPI
 import SwiftyRequest
 import SwiftJWKtoPEM
 import SwiftyJSON
@@ -33,9 +33,9 @@ public class APIKituraCredentialsPlugin: AppIDPlugin, CredentialsPluginProtocol 
 
     public init(options: [String: Any]?) {
         let config = AppIDPluginConfig(options: options, validateEntireToken: false, required: \.serverUrl, \.clientId, \.tenantId)
-        super.init(logger: Logger(forName: Constants.APIPlugin.name), config: config)
+        super.init(config: config)
 
-        logger.warn("This is a beta version of APIKituraCredentialsPlugin." +
+        Log.warning("This is a beta version of APIKituraCredentialsPlugin." +
                     "It should not be used for production environments!")
 
     }
@@ -48,7 +48,7 @@ public class APIKituraCredentialsPlugin: AppIDPlugin, CredentialsPluginProtocol 
                               onPass: @escaping (HTTPStatusCode?, [String: String]?) -> Void,
                               inProgress: @escaping () -> Void) {
 
-        logger.debug("authenticate")
+        Log.debug("authenticate")
 
         var requiredScope = Constants.AppID.defaultScope
 
@@ -57,19 +57,19 @@ public class APIKituraCredentialsPlugin: AppIDPlugin, CredentialsPluginProtocol 
         }
 
         guard let authHeaderComponents = request.headers[Constants.authHeader]?.components(separatedBy: " ") else {
-            logger.warn("Authorization header not found")
+            Log.warning("Authorization header not found")
             sendUnauthorized(scope: requiredScope, error: .missingAuth, completion: onPass)
             return
         }
 
         guard authHeaderComponents.first == Constants.bearer else {
-            logger.warn("Unrecognized Authorization Method")
+            Log.warning("Unrecognized Authorization Method")
             sendUnauthorized(scope: requiredScope, error: .invalidRequest, completion: onPass)
             return
         }
         // authHeader format :: "Bearer accessToken idToken"
         guard authHeaderComponents.count == 3 || authHeaderComponents.count == 2 else {
-            logger.warn("Invalid authorization header format")
+            Log.warning("Invalid authorization header format")
             sendUnauthorized(scope: requiredScope, error: .invalidRequest, completion: onFailure)
             return
         }
@@ -146,14 +146,14 @@ extension APIKituraCredentialsPlugin {
         }
 
         guard let scope = payload["scope"] as? String else {
-            logger.warn("Access token does not contain the required scopes")
+            Log.warning("Access token does not contain the required scopes")
             return false
         }
 
         let suppliedScopeElement = Set(scope.components(separatedBy: " "))
         for requiredScopeElement in requiredScopeElements {
             if !suppliedScopeElement.contains(requiredScopeElement) {
-                logger.warn("Access token does not contain required scope. Expected " +
+                Log.warning("Access token does not contain required scope. Expected " +
                             " \(requiredScope) + received + \(scope)")
                 return false
             }

--- a/Sources/IBMCloudAppID/AppIDPlugin.swift
+++ b/Sources/IBMCloudAppID/AppIDPlugin.swift
@@ -11,7 +11,7 @@
  limitations under the License.
  */
 import Foundation
-import SimpleLogger
+import LoggerAPI
 import Credentials
 import KituraNet
 
@@ -22,14 +22,11 @@ import KituraNet
 @available(OSX 10.12, *)
 public class AppIDPlugin {
 
-    let logger: Logger
-
     var publicKeyUtil: PublicKeyUtil
 
     let config: AppIDPluginConfig
 
-    init(logger: Logger, config: AppIDPluginConfig) {
-        self.logger = logger
+    init(config: AppIDPluginConfig) {
         self.config = config
         self.publicKeyUtil = PublicKeyUtil(url: config.publicKeyServerURL)
     }
@@ -42,23 +39,23 @@ public class AppIDPlugin {
     func parseIdentityToken(idTokenString: String?, completion: @escaping (([String: Any], UserProfile)?, AppIDError?) -> Void) {
 
         guard let idTokenString = idTokenString else {
-            logger.debug("Identity token does not exist")
+            Log.debug("Identity token does not exist")
             return completion(nil, AppIDError.invalidToken("Identity token does not exist"))
         }
 
         Utils.decodeAndValidate(tokenString: idTokenString, publicKeyUtil: publicKeyUtil, options: config) { payload, error in
 
             guard let payload = payload, error == nil else {
-                self.logger.debug("Identity token is malformed")
+                Log.debug("Identity token is malformed")
                 return completion(nil, error ?? AppIDError.invalidToken("Identity token could not be decoded"))
             }
 
             guard let authContext = Utils.getAuthorizedIdentities(from: payload) else {
-                self.logger.debug("Identity token is malformed")
+                Log.debug("Identity token is malformed")
                 return completion(nil, error ?? AppIDError.invalidToken("Identity token could not be decoded"))
             }
 
-            self.logger.debug("Identity token successfully parsed")
+            Log.debug("Identity token successfully parsed")
 
             let identityContext = [
                 "identityToken": idTokenString,
@@ -89,7 +86,7 @@ public class AppIDPlugin {
                                   description: String? = nil,
                                   completion: @escaping (HTTPStatusCode?, [String: String]?) -> Void) {
 
-        logger.debug("Sending unauthorized response")
+        Log.debug("Sending unauthorized response")
 
         var msg = Constants.bearer + " scope=\"" + scope + "\", error=\"" + error.rawValue + "\""
         var status: HTTPStatusCode!

--- a/Sources/IBMCloudAppID/AppIDPluginConfig.swift
+++ b/Sources/IBMCloudAppID/AppIDPluginConfig.swift
@@ -12,14 +12,12 @@
  */
 
 import Foundation
-import SimpleLogger
+import LoggerAPI
 import SwiftyJSON
 
 /// App ID Configuration Plugin - VCAP / Options parser
 ///
 class AppIDPluginConfig {
-
-    private let logger = Logger(forName: Constants.Utils.configuration)
 
     var serviceConfig: [String: Any] = [:]
 
@@ -80,7 +78,7 @@ class AppIDPluginConfig {
 
         self.shouldValidateAudAndIssuer = validateEntireToken
 
-        logger.debug("Intializing configuration")
+        Log.debug("Intializing configuration")
 
         let options = options ?? [:]
         let vcapString = ProcessInfo.processInfo.environment[Constants.VCAP.services] ?? ""
@@ -124,15 +122,15 @@ class AppIDPluginConfig {
         /// Assert configuration has required fields
         for path in required {
             if self[keyPath: path] == nil {
-                logger.error("Failed to fully initialize configuration." +
+                Log.error("Failed to fully initialize configuration." +
                     " To ensure complete functionality, ensure your app is either bound to an" +
                     " App ID service instance or pass the required parameters to the constructor")
                 break
             }
         }
 
-        logger.info("ServerUrl: " + (serverUrl ?? "unset"))
-        logger.info("ProfilesUrl: " + (userProfileServerUrl ?? "unset"))
+        Log.info("ServerUrl: " + (serverUrl ?? "unset"))
+        Log.info("ProfilesUrl: " + (userProfileServerUrl ?? "unset"))
     }
 
 }

--- a/Sources/IBMCloudAppID/PublicKeysUtil.swift
+++ b/Sources/IBMCloudAppID/PublicKeysUtil.swift
@@ -11,7 +11,7 @@
  limitations under the License.
  */
 
-import SimpleLogger
+import LoggerAPI
 import SwiftyRequest
 import SwiftJWKtoPEM
 import Foundation
@@ -38,13 +38,11 @@ public class PublicKeyUtil {
 
     private let stateQueue = DispatchQueue(label: "stateQueue")
 
-    private let logger = Logger(forName: Constants.Utils.publicKey)
-
     public init(url: String?) {
         if let url = url {
             publicKeyUrl = url
         } else {
-            logger.debug("Request public key url not supplied ")
+            Log.debug("Request public key url not supplied ")
         }
 
         /// Initiate first public keys request
@@ -152,14 +150,14 @@ public class PublicKeyUtil {
     private func updatePublicKeys(completion: @escaping ([String: String]?, AppIDError?) -> Void) {
 
         guard let publicKeyUrl = self.publicKeyUrl else {
-            logger.error("Cannot retrieve public keys. Missing OAuth server url.")
+            Log.error("Cannot retrieve public keys. Missing OAuth server url.")
             return completion(nil, .missingPublicKey)
         }
 
         sendRequest(url: publicKeyUrl) { data, response, error in
 
             guard error == nil, let response = response, let data = data else {
-                self.logger.debug("An error occured in the public key retrieval response. Error: \(error?.localizedDescription ?? "")")
+                Log.debug("An error occured in the public key retrieval response. Error: \(error?.localizedDescription ?? "")")
                 return completion(nil, .missingPublicKey)
             }
             self.handlePubKeyResponse(status: response.statusCode, data: data, completion: completion)
@@ -172,7 +170,7 @@ public class PublicKeyUtil {
     private func handlePubKeyResponse(status: Int?, data: Data, completion: @escaping ([String: String]?, AppIDError?) -> Void) {
 
         guard status == 200 else {
-            logger.debug("Failed to obtain public key " +
+            Log.debug("Failed to obtain public key " +
                 "status code \(String(describing: status))\n" +
                 "body \(String(data: data, encoding: .utf8) ?? "")")
             return completion(nil, .missingPublicKey)
@@ -180,7 +178,7 @@ public class PublicKeyUtil {
 
         guard let json = try? JSONDecoder().decode([String: [PublicKey]].self, from: data),
             let tokens = json["keys"] else {
-                logger.debug("Unable to decode data from public key response")
+                Log.debug("Unable to decode data from public key response")
                 return completion(nil, .missingPublicKey)
         }
 
@@ -190,7 +188,7 @@ public class PublicKeyUtil {
 
             guard let pemKey = try? RSAKey(n: key.n, e: key.e).getPublicKey(certEncoding.pemPkcs8),
                 let publicKey = pemKey else {
-                    logger.debug("Failed to convert public key to pemPkcs: \(key)")
+                    Log.debug("Failed to convert public key to pemPkcs: \(key)")
                     return dict
             }
             dict[key.kid] = publicKey
@@ -198,7 +196,7 @@ public class PublicKeyUtil {
             return dict
         }
 
-        logger.debug("Public keys retrieved and extracted")
+        Log.debug("Public keys retrieved and extracted")
 
         self.publicKeys = publicKeys
         completion(publicKeys, nil)

--- a/Sources/IBMCloudAppID/Utils.swift
+++ b/Sources/IBMCloudAppID/Utils.swift
@@ -13,21 +13,19 @@
 
 import Foundation
 import SwiftyJSON
-import SimpleLogger
+import LoggerAPI
 import CryptorRSA
 
 @available(OSX 10.12, *)
 class Utils {
 
-    private static let logger = Logger(forName: Constants.Utils.appId)
-
     static func getAuthorizedIdentities(from idToken: JSON) -> AuthorizationContext? {
-        logger.debug("APIStrategy getAuthorizedIdentities")
+        Log.debug("APIStrategy getAuthorizedIdentities")
         return AuthorizationContext(idTokenPayload: idToken["payload"])
     }
 
     static func getAuthorizedIdentities(from idToken: [String: Any]) -> AuthorizationContext? {
-        logger.debug("APIStrategy getAuthorizedIdentities")
+        Log.debug("APIStrategy getAuthorizedIdentities")
         guard let json = try? JSONSerialization.data(withJSONObject: idToken, options: .prettyPrinted) else {
             return nil
         }
@@ -39,14 +37,14 @@ class Utils {
         let tokenComponents = tokenString.components(separatedBy: ".")
 
         guard tokenComponents.count == 3 else {
-            logger.error("Invalid access token format")
+            Log.error("Invalid access token format")
             throw AppIDError.invalidTokenFormat
         }
 
         guard let jwtHeaderData = tokenComponents[0].base64decodedData(),
               let jwtPayloadData = tokenComponents[1].base64decodedData()
         else {
-            logger.error("Invalid access token format")
+            Log.error("Invalid access token format")
             throw AppIDError.invalidTokenFormat
         }
 
@@ -88,14 +86,14 @@ class Utils {
 
         isValid = try message.verify(with: tokenPublicKey, signature: signature, algorithm: .sha256)
         if !isValid {
-	        logger.error("invalid signature on token")
+	        Log.error("invalid signature on token")
         }
 
         return isValid
     }
 
     static func isTokenValid(token: String) -> Bool {
-        logger.debug("isTokenValid")
+        Log.debug("isTokenValid")
         if let jwt = try? parseToken(from: token) {
             let jwtPayload = jwt["payload"].dictionary
 
@@ -123,7 +121,7 @@ class Utils {
                                   completion: @escaping ([String: Any]?, AppIDError?) -> Void) {
 
         func logAndReturn(_ error: AppIDError, completion: @escaping ([String: Any]?, AppIDError?) -> Void) {
-            logger.debug("Unable to validate token: " + error.description)
+            Log.debug("Unable to validate token: " + error.description)
             completion(nil, error)
         }
 

--- a/Sources/IBMCloudAppID/WebAppKituraCredentialsPlugin.swift
+++ b/Sources/IBMCloudAppID/WebAppKituraCredentialsPlugin.swift
@@ -17,7 +17,7 @@ import Credentials
 import KituraNet
 import SwiftyRequest
 import SwiftyJSON
-import SimpleLogger
+import LoggerAPI
 import KituraSession
 
 @available(OSX 10.12, *)
@@ -33,7 +33,7 @@ public class WebAppKituraCredentialsPlugin: AppIDPlugin, CredentialsPluginProtoc
 
     public init(options: [String: Any]?) {
         let config = AppIDPluginConfig(options: options, required: \.serverUrl, \.clientId, \.tenantId, \.secret, \.redirectUri)
-        super.init(logger: Logger(forName: Constants.WebAppPlugin.name), config: config)
+        super.init(config: config)
     }
 
     public func authenticate (request: RouterRequest,
@@ -45,13 +45,13 @@ public class WebAppKituraCredentialsPlugin: AppIDPlugin, CredentialsPluginProtoc
                               inProgress: @escaping () -> Void) {
 
         if request.session == nil {
-            logger.error("Can't find request.session. Ensure KituraSession middleware is in use")
+            Log.error("Can't find request.session. Ensure KituraSession middleware is in use")
             onFailure(nil, nil)
             return
         }
 
         if let error = request.queryParameters["error"] {
-            logger.warn("Error returned in callback " + error)
+            Log.warning("Error returned in callback " + error)
             onFailure(nil, nil)
         } else if let code = request.queryParameters["code"] {
             return handleAuthorizationCallback(code: code, request: request, onSuccess: onSuccess, onFailure: onFailure)
@@ -140,14 +140,14 @@ extension WebAppKituraCredentialsPlugin {
                                       onPass: @escaping (HTTPStatusCode?, [String: String]?) -> Void,
                                       inProgress: @escaping () -> Void) {
 
-        logger.debug("WebAppKituraCredentialsPlugin :: handleAuthorization")
+        Log.debug("WebAppKituraCredentialsPlugin :: handleAuthorization")
         let forceLogin: Bool = options[Constants.AppID.forceLogin] as? Bool ?? false
         let allowAnonymousLogin: Bool = options[Constants.AppID.allowAnonymousLogin] as? Bool ?? false
         let allowCreateNewAnonymousUser: Bool = options[Constants.AppID.allowCreateNewAnonymousUser] as? Bool ?? true
         // If user is already authenticated and new login is not enforced - end processing
         // Otherwise - persist original request url and redirect to authorization
         if let requestUserProfile = request.userProfile, !forceLogin && !allowAnonymousLogin {
-            logger.debug("ALREADY AUTHENTICATED!!!")
+            Log.debug("ALREADY AUTHENTICATED!!!")
             return onSuccess(requestUserProfile)
         } else {
             //			request.session?[OriginalUrl] = JSON(request.originalURL)
@@ -156,7 +156,7 @@ extension WebAppKituraCredentialsPlugin {
         let requestProfile = request.userProfile
         if forceLogin != true && allowAnonymousLogin != true {
             if requestProfile != nil || sessionProfile?.isEmpty == false {
-                logger.debug("ALREADY AUTHENTICATED!!!")
+                Log.debug("ALREADY AUTHENTICATED!!!")
                 if let session = request.session, let profile = restoreUserProfile(from: session) {
                     return onSuccess(profile)
                 }
@@ -169,26 +169,25 @@ extension WebAppKituraCredentialsPlugin {
         if let appIdAuthContext = request.session?[Constants.AuthContext.name] as? [String : Any] {
             let payload = appIdAuthContext["accessTokenPayload"] as? [String : Any]
             if (payload?["amr"] as? [String])?[0] ==  "appid_anon" {
-                logger.debug("WebAppKituraCredentialsPlugin :: handleAuthorization :: added anonymous access_token to url")
+                Log.debug("WebAppKituraCredentialsPlugin :: handleAuthorization :: added anonymous access_token to url")
                 authUrl += "&appid_access_token=" + ((appIdAuthContext["accessToken"] as? String) ?? "")
             }
         } else if allowAnonymousLogin && !allowCreateNewAnonymousUser {
             // If previous anonymous access token not found and new anonymous users are not allowed - fail
-            logger.warn("Previous anonymous user not found. Not allowed to create new anonymous users.")
+            Log.warning("Previous anonymous user not found. Not allowed to create new anonymous users.")
             return onFailure(nil, nil)
         }
 
-        // Store and add high entropy state
         guard let state = generateState(of: 24) else {
-            logger.error("Could not generate a state parameter. Please try again.")
+            Log.error("Could not generate a state parameter. Please try again.")
             return onFailure(nil, nil)
         }
 
         authUrl += "&state=\(state)"
-        logger.debug(authUrl)
+        Log.debug(authUrl)
         request.session?[Constants.context] = [Constants.state: state, Constants.isAnonymous: authUrl.range(of: "idp=appid_anon") != nil]
 
-        logger.debug("Redirecting to : " + authUrl)
+        Log.debug("Redirecting to : " + authUrl)
 
         do {
             try response.redirect(authUrl)
@@ -207,12 +206,12 @@ extension WebAppKituraCredentialsPlugin {
         /// Validate state parameter in session matches response state
         guard let context = request.session?[Constants.context] as? [String: Any],
             let isAnonymous = context[Constants.isAnonymous] as? Bool else {
-            logger.error("The session is missing the required context")
+            Log.error("The session is missing the required context")
             return onFailure(nil, nil)
         }
 
         guard let storedState = context[Constants.state] as? String else {
-            logger.error("The expected state parameter was not found in the request session")
+            Log.error("The expected state parameter was not found in the request session")
             return onFailure(nil, nil)
         }
 
@@ -220,12 +219,12 @@ extension WebAppKituraCredentialsPlugin {
         if !isAnonymous {
 
             guard let returnedState = getRequestState(from: request) else {
-                logger.error("The redirect URI does not have required state")
+                Log.error("The redirect URI does not have required state")
                 return onFailure(nil, nil)
             }
 
             guard storedState == returnedState else {
-                logger.error("Stored State does not match redirect uri state query parameter")
+                Log.error("Stored State does not match redirect uri state query parameter")
                 return onFailure(nil, nil)
             }
         }
@@ -239,7 +238,7 @@ extension WebAppKituraCredentialsPlugin {
                                     onSuccess: @escaping (UserProfile) -> Void,
                                     onFailure: @escaping (HTTPStatusCode?, [String: String]?) -> Void) {
 
-        logger.debug("WebAppKituraCredentialsPlugin :: retrieveTokens")
+        Log.debug("WebAppKituraCredentialsPlugin :: retrieveTokens")
 
         guard let clientId = config.clientId,
               let secret = config.secret,
@@ -262,7 +261,7 @@ extension WebAppKituraCredentialsPlugin {
         if let json = try? JSONSerialization.data(withJSONObject: params, options: []) {
             restReq.messageBody = json
         } else {
-            logger.debug("Failed to parse data into JSON.")
+            Log.debug("Failed to parse data into JSON.")
         }
 
         self.executeRequest(restReq) { (tokenData, tokenResponse, tokenError) in
@@ -286,19 +285,19 @@ extension WebAppKituraCredentialsPlugin {
         let code = httpCode.map { String(describing: $0) } ?? "<no http code>"
         if let tokenError = tokenError {
             let errorMessage = String(describing: tokenError)
-            self.logger.debug("WebAppKituraCredentialsPlugin :: Failed to obtain tokens. error message " +
+            Log.debug("WebAppKituraCredentialsPlugin :: Failed to obtain tokens. error message " +
                 ": \(errorMessage)\nstatus code : \(code)\ntoken body : \(String(describing: tokenData))")
             return onFailure(nil, nil)
         }
 
         guard let tokenData = tokenData else {
-            self.logger.debug("WebAppKituraCredentialsPlugin :: Failed to obtain tokens." +
+            Log.debug("WebAppKituraCredentialsPlugin :: Failed to obtain tokens." +
                 " No token error message. No token data. status code : \(code)")
             return onFailure(nil, nil)
         }
 
         guard httpCode == 200 else {
-            self.logger.debug("WebAppKituraCredentialsPlugin :: Failed to obtain tokens." +
+            Log.debug("WebAppKituraCredentialsPlugin :: Failed to obtain tokens." +
                 " Status code wasn't 200. No token error message. status code :" +
                 " \(code)\n token body : \(String(describing: tokenData))")
             return onFailure(nil, nil)
@@ -337,7 +336,7 @@ extension WebAppKituraCredentialsPlugin {
                 originalRequest.session?[Constants.AuthContext.name] = authorizationContext
                 onSuccess(context.1)
 
-                self.logger.debug("retrieveTokens :: tokens retrieved")
+                Log.debug("retrieveTokens :: tokens retrieved")
             }
         }
     }
@@ -357,7 +356,7 @@ extension WebAppKituraCredentialsPlugin {
         }
         query = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
         let authUrl = "\(authorizationEndpoint)?\(query)"
-        self.logger.debug("AUTHURL: \(authUrl)")
+        Log.debug("AUTHURL: \(authUrl)")
         return authUrl
     }
 

--- a/Tests/IBMCloudAppIDTests/ApiPluginTests.swift
+++ b/Tests/IBMCloudAppIDTests/ApiPluginTests.swift
@@ -12,7 +12,7 @@
  */
 import XCTest
 import Kitura
-import SimpleLogger
+import LoggerAPI
 import Credentials
 @testable import KituraNet
 @testable import Kitura
@@ -44,8 +44,6 @@ class ApiPluginTests: XCTestCase {
         ]
     }
 
-    let logger = Logger(forName:"ApiPluginTest")
-
     class MockAPIKituraCredentialsPlugin: APIKituraCredentialsPlugin {
 
         init(options: [String: Any]?, responseCode: Int = 200, responseBody: String = "{\"keys\": [\(TestConstants.PUBLIC_KEY)]}") {
@@ -64,6 +62,7 @@ class ApiPluginTests: XCTestCase {
     var response: RouterResponse!
 
     override func setUp() {
+        Log.logger = PrintLogger(colored: true)
         unsetenv("VCAP_SERVICES")
         unsetenv("redirectUri")
         parser = HTTPParser(isRequest: true)
@@ -298,7 +297,7 @@ extension ApiPluginTests {
 
     // Remove off_ for running
     func off_testRunWebAppServer() {
-        logger.debug("Starting")
+        Log.debug("Starting")
 
         let router = Router()
 

--- a/Tests/IBMCloudAppIDTests/PrintLogger.swift
+++ b/Tests/IBMCloudAppIDTests/PrintLogger.swift
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corporation 2016, 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+import LoggerAPI
+
+/// The set of colors used when logging with colorized lines
+public enum TerminalColor: String {
+    /// Log text in white.
+    case white = "\u{001B}[0;37m" // white
+    /// Log text in red, used for error messages.
+    case red = "\u{001B}[0;31m" // red
+    /// Log text in yellow, used for warning messages.
+    case yellow = "\u{001B}[0;33m" // yellow
+    /// Log text in the terminal's default foreground color.
+    case foreground = "\u{001B}[0;39m" // default foreground color
+    /// Log text in the terminal's default background color.
+    case background = "\u{001B}[0;49m" // default background color
+}
+
+public class PrintLogger: Logger {
+    let colored: Bool
+
+    init(colored: Bool) {
+        self.colored = colored
+    }
+
+    public func log(_ type: LoggerMessageType, msg: String,
+                    functionName: String, lineNum: Int, fileName: String ) {
+        let message = "[\(type)] [\(getFile(fileName)):\(lineNum) \(functionName)] \(msg)"
+
+        guard colored else {
+            print(message)
+            return
+        }
+
+        let color: TerminalColor
+        switch type {
+        case .warning:
+            color = .yellow
+        case .error:
+            color = .red
+        default:
+            color = .foreground
+        }
+
+        print(color.rawValue + message + TerminalColor.foreground.rawValue)
+    }
+
+    public func isLogging(_ level: LoggerAPI.LoggerMessageType) -> Bool {
+        return true
+    }
+
+    public static func use(colored: Bool) {
+        Log.logger = PrintLogger(colored: colored)
+        setbuf(stdout, nil)
+    }
+
+    private func getFile(_ path: String) -> String {
+        guard let range = path.range(of: "/", options: .backwards) else {
+            return path
+        }
+
+        return String(path[range.upperBound...])
+    }
+}

--- a/Tests/IBMCloudAppIDTests/UserProfileManagerTests.swift
+++ b/Tests/IBMCloudAppIDTests/UserProfileManagerTests.swift
@@ -12,11 +12,7 @@
  */
 import XCTest
 import Foundation
-import Credentials
-import KituraSession
 import SwiftyJSON
-import Kitura
-import SimpleLogger
 @testable import Credentials
 @testable import KituraNet
 @testable import Kitura
@@ -80,7 +76,6 @@ class UserProfileManagerTests: XCTestCase {
     static let AccessTokenSuccessMismatchedSubjects = "accessToken_mismatched_subjects"
     let IdentityTokenSubject123 = "ifQ.eyJzdWIiOiJzdWJqZWN0MTIzIn0.Q"
     let AccessTokenFailure = "accessToken,return_error"
-    let logger = Logger(forName:"UserProfileManagerTest")
     let fullOptions =  ["clientId": "someclient",
                         "secret": "somesecret",
                         "tenantId": "sometenant",

--- a/Tests/IBMCloudAppIDTests/UtilsTest.swift
+++ b/Tests/IBMCloudAppIDTests/UtilsTest.swift
@@ -11,20 +11,12 @@
  limitations under the License.
  */
 import XCTest
-import Kitura
-import SimpleLogger
-import Credentials
-import KituraSession
 import SwiftyJSON
-import XCTest
-import Kitura
-import SimpleLogger
 @testable import Credentials
 @testable import KituraNet
 @testable import Kitura
 @testable import KituraSession
 import Socket
-import SwiftyJSON
 
 @testable import IBMCloudAppID
 

--- a/Tests/IBMCloudAppIDTests/WebAppPluginTest.swift
+++ b/Tests/IBMCloudAppIDTests/WebAppPluginTest.swift
@@ -11,21 +11,16 @@
  limitations under the License.
  */
 import XCTest
-import Kitura
-import SimpleLogger
 import Credentials
-import KituraSession
 import SwiftyJSON
 import XCTest
-import Kitura
-import SimpleLogger
 import SwiftyRequest
+import LoggerAPI
 @testable import Credentials
 @testable import KituraNet
 @testable import Kitura
 @testable import KituraSession
 import Socket
-import SwiftyJSON
 import Foundation
 
 @testable import IBMCloudAppID
@@ -63,8 +58,11 @@ class WebAppPluginTest: XCTestCase {
         ]
     }
 
-    let logger = Logger(forName:"WebAppPluginTest")
     let expectedState = "abc123"
+
+    override func setUp() {
+        Log.logger = PrintLogger(colored: true)
+    }
 
     func testLogout() {
 
@@ -425,7 +423,7 @@ class WebAppPluginTest: XCTestCase {
 
     // Remove off_ to run sample app
     func off_testRunWebAppServer() {
-        logger.debug("Starting")
+        Log.debug("Starting")
 
         let options = ["": ""]
 


### PR DESCRIPTION
Replaces the `SimpleLogger` from [ibm-bluemix-mobile-services/bluemix-simple-logger-swift](https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift) with `LoggerAPI` [(IBM-Swift/LoggerAPI)](https://github.com/IBM-Swift/LoggerAPI).

Adds the PrintLogger implementation (used by Kitura) to the tests.

This resolves issue #83.