### PR TITLE
feat: Add support for v4 AppID API

### DIFF
--- a/Sources/IBMCloudAppID/AppIDPluginConfig.swift
+++ b/Sources/IBMCloudAppID/AppIDPluginConfig.swift
@@ -49,10 +49,16 @@ class AppIDPluginConfig {
         guard let sUrl = serverUrl, let url = URL(string: sUrl) else {
             return nil
         }
-        if let host = url.host, let port = url.port {
-            return "\(host):\(port)"
+        let hostURL: String?
+        if url.absoluteString.contains("oauth/v4") {
+            hostURL = url.absoluteString
+        } else {
+            hostURL = url.host
         }
-        return url.host
+        guard host = hostURL, let port = url.port else {
+            return hostURL
+        }
+        return "\(host):\(port)"
     }
 
     var publicKeyServerURL: String? {

--- a/Sources/IBMCloudAppID/AppIDPluginConfig.swift
+++ b/Sources/IBMCloudAppID/AppIDPluginConfig.swift
@@ -55,7 +55,7 @@ class AppIDPluginConfig {
         } else {
             hostURL = url.host
         }
-        guard host = hostURL, let port = url.port else {
+        guard let host = hostURL, let port = url.port else {
             return hostURL
         }
         return "\(host):\(port)"

--- a/Sources/IBMCloudAppID/Token.swift
+++ b/Sources/IBMCloudAppID/Token.swift
@@ -37,7 +37,7 @@ public class Token {
     }
 
     public var aud: String? {
-        return payload["aud"].string
+        return payload["aud"].string ?? payload["aud"].array?.first?.string
     }
 
     public var iss: String? {


### PR DESCRIPTION
When you make a new AppID service you are given the new v4 API which is not currently supported by this repo. 

This pull request updates the tokenIssuer and aud so that they can successfully by decoded on both the v3 and v4 API.