### PR TITLE
Support Swift 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       sudo: required
+    - os: osx
+      osx_image: xcode11
+      sudo: required
 
 sudo: required
 

--- a/Sources/IBMCloudAppID/PublicKeysUtil.swift
+++ b/Sources/IBMCloudAppID/PublicKeysUtil.swift
@@ -17,6 +17,12 @@ import SwiftJWKtoPEM
 import Foundation
 import Dispatch
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 /// Public Key utility class.
 /// - Responsible for retrieving and storing App ID public keys
 public class PublicKeyUtil {

--- a/Sources/IBMCloudAppID/WebAppKituraCredentialsPlugin.swift
+++ b/Sources/IBMCloudAppID/WebAppKituraCredentialsPlugin.swift
@@ -20,6 +20,12 @@ import SwiftyJSON
 import LoggerAPI
 import KituraSession
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 @available(OSX 10.12, *)
 public class WebAppKituraCredentialsPlugin: AppIDPlugin, CredentialsPluginProtocol {
 
@@ -303,7 +309,7 @@ extension WebAppKituraCredentialsPlugin {
             return onFailure(nil, nil)
         }
 
-        var body = JSON(data: tokenData)
+        let body = JSON(data: tokenData)
 
         /// Parse access_token
         guard let accessTokenString = body["access_token"].string else {

--- a/Tests/IBMCloudAppIDTests/MockPublicKeyUtil.swift
+++ b/Tests/IBMCloudAppIDTests/MockPublicKeyUtil.swift
@@ -14,6 +14,12 @@
 import Foundation
 @testable import IBMCloudAppID
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 class MockPublicKeyUtil: PublicKeyUtil {
     var publicKeyResponseCode: Int
     var publicKeyResponse: String

--- a/Tests/IBMCloudAppIDTests/WebAppPluginTest.swift
+++ b/Tests/IBMCloudAppIDTests/WebAppPluginTest.swift
@@ -25,6 +25,12 @@ import Socket
 
 import Foundation
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 @testable import IBMCloudAppID
 
 @available(OSX 10.12, *)


### PR DESCRIPTION
Resolve compilation errors and warnings relating to changes in the Swift 5.1 release:
- `import FoundationNetworking` on Linux to access `HTTPCookie` and similar types, due to [changes to Foundation structure](https://forums.swift.org/t/foundationnetworking/24769)
- fix compilation warnings relating to a `var` that was never mutated
- add an `xcode11` Travis build